### PR TITLE
Adding Support for NSS product name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ before_install:
 - rm -rf dependencies
 - mv sidebar.yml _data/sidebars/
 - sed -i 's/\/jekyll/'$JEKYLL_BASEURL'/g' ./_config.yml
-#- echo "nss_product{{':'}} OnCommand Cloud Manager" >> ./_config.yml
 - sed -i -e "\$anss_product\:\ OnCommand Cloud Manager" ./_config.yml
 script:
-- grep nss_product ./_config.yml
-#- bundle exec rake deploy
+- bundle exec rake deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,7 @@ before_install:
 - rm -rf dependencies
 - mv sidebar.yml _data/sidebars/
 - sed -i 's/\/jekyll/'$JEKYLL_BASEURL'/g' ./_config.yml
+- echo "nss_product: $NSS_PRODUCT" >> ./_config.yml
 script:
-- bundle exec rake deploy
+- grep nss_product ./_config.yml
+#- bundle exec rake deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_install:
 - rm -rf dependencies
 - mv sidebar.yml _data/sidebars/
 - sed -i 's/\/jekyll/'$JEKYLL_BASEURL'/g' ./_config.yml
-- echo \"nss_product: OnCommand Cloud Manager\" >> ./_config.yml
+#- echo "nss_product{{':'}} OnCommand Cloud Manager" >> ./_config.yml
+- sed -i -e "\$anss_product\:\sOnCommand Cloud Manager" >> ./_config.yml
 script:
 - grep nss_product ./_config.yml
 #- bundle exec rake deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ before_install:
 - rm -rf dependencies
 - mv sidebar.yml _data/sidebars/
 - sed -i 's/\/jekyll/'$JEKYLL_BASEURL'/g' ./_config.yml
-- echo "nss_product: $NSS_PRODUCT" >> ./_config.yml
+- ls -al
+- echo "nss_product:OnCommand Cloud Manager" >> ./_config.yml
 script:
 - grep nss_product ./_config.yml
 #- bundle exec rake deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 - mv sidebar.yml _data/sidebars/
 - sed -i 's/\/jekyll/'$JEKYLL_BASEURL'/g' ./_config.yml
 #- echo "nss_product{{':'}} OnCommand Cloud Manager" >> ./_config.yml
-- sed -i -e "\$anss_product\:\sOnCommand Cloud Manager" >> ./_config.yml
+- sed -i -e "\$anss_product\:\ OnCommand Cloud Manager" ./_config.yml
 script:
 - grep nss_product ./_config.yml
 #- bundle exec rake deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ before_install:
 - mv sidebar.yml _data/sidebars/
 - sed -i 's/\/jekyll/'$JEKYLL_BASEURL'/g' ./_config.yml
 - ls -al
-- echo "nss_product: OnCommand Cloud Manager" >> ./_config.yml
+- echo "nss_product:OnCommand Cloud Manager" >> ./_config.yml
 script:
 - bundle exec rake deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
 - mv sidebar.yml _data/sidebars/
 - sed -i 's/\/jekyll/'$JEKYLL_BASEURL'/g' ./_config.yml
 - ls -al
-- echo "nss_product:OnCommand Cloud Manager" >> ./_config.yml
+- echo "nss_product: OnCommand Cloud Manager" >> ./_config.yml
 script:
-- grep nss_product ./_config.yml
-#- bundle exec rake deploy
+- bundle exec rake deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 - rm -rf dependencies
 - mv sidebar.yml _data/sidebars/
 - sed -i 's/\/jekyll/'$JEKYLL_BASEURL'/g' ./_config.yml
-- echo "nss_product':' OnCommand Cloud Manager" >> ./_config.yml
+- echo \"nss_product: OnCommand Cloud Manager\" >> ./_config.yml
 script:
 - grep nss_product ./_config.yml
 #- bundle exec rake deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 - rm -rf dependencies
 - mv sidebar.yml _data/sidebars/
 - sed -i 's/\/jekyll/'$JEKYLL_BASEURL'/g' ./_config.yml
-- ls -al
-- echo "nss_product:OnCommand Cloud Manager" >> ./_config.yml
+- echo "nss_product':' OnCommand Cloud Manager" >> ./_config.yml
 script:
-- bundle exec rake deploy
+- grep nss_product ./_config.yml
+#- bundle exec rake deploy


### PR DESCRIPTION
This PR adds the product name meta tag, which allows users to filter on products within NSS Search.
`<meta http-equiv="nss-product" content="OnCommand Cloud Manager">`