### PR TITLE
Fixing the search json index

### DIFF
--- a/task_tiering.adoc
+++ b/task_tiering.adoc
@@ -28,11 +28,11 @@ Data tiering is supported with specific configurations and features:
 +
 It is not supported with ONTAP Cloud Explore or with M3 and R3 instance types when using Standard and Premium.
 
+* The EBS tier can be General Purpose SSDs or Throughput Optimized HDDs.
+
 * Data tiering is supported with AWS-managed encryption.
 +
 It is not supported with ONTAP Cloud-managed encryption.
-
-* The EBS tier can be General Purpose SSDs or Throughput Optimized HDDs.
 
 * Thin provisioning must be enabled on volumes.
 

--- a/task_tiering.adoc
+++ b/task_tiering.adoc
@@ -32,6 +32,8 @@ It is not supported with ONTAP Cloud Explore or with M3 and R3 instance types wh
 +
 It is not supported with ONTAP Cloud-managed encryption.
 
+* The EBS tier can be General Purpose SSDs or Throughput Optimized HDDs.
+
 * Thin provisioning must be enabled on volumes.
 
 * ONTAP performance enhancements introduced in ONTAP Cloud 9.2 are not supported with data tiering.

--- a/task_tiering.adoc
+++ b/task_tiering.adoc
@@ -2,7 +2,7 @@
 sidebar: sidebar
 permalink: task_tiering.html
 keywords: tier, tiering, cold data, hot data, storage tiering, data tiering, S3 tiering, fabricpool, fabric pool, s3 endpoint, endpoint, connection, performance tier, capacity tier, object store
-summary: You can reduce storage costs in AWS by combining an EBS performance tier for "hot" data with an S3 capacity tier for "cold" data.
+summary: You can reduce storage costs in AWS by combining an EBS performance tier for hot data with an S3 capacity tier for cold data.
 ---
 
 = Tiering data in AWS
@@ -27,8 +27,6 @@ Data tiering is supported with specific configurations and features:
 * Data tiering is supported with ONTAP Cloud Standard, Premium, and BYOL.
 +
 It is not supported with ONTAP Cloud Explore or with M3 and R3 instance types when using Standard and Premium.
-
-* The EBS tier can be General Purpose SSDs or Throughput Optimized HDDs.
 
 * Data tiering is supported with AWS-managed encryption.
 +


### PR DESCRIPTION
The [Json Search Index](https://github.com/NetAppDocs/occm/blob/93552073d5829a8169a8e39ea4e748dec3553560/en/search.json#L704) does not support double quotes within properties.

I have removed the double quotes. 


