### PR TITLE
Switching GA account

### DIFF
--- a/api.html
+++ b/api.html
@@ -11,13 +11,13 @@
 <link rel="stylesheet" href="./css/netapp.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css">
 <link rel="icon" href="/occm/en/images/favicon.ico">
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-81697994-2"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-81697994-3"></script>
 <script>
 if (document.location.hostname.search("netapp.com") !== -1) {
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'UA-81697994-2');
+  gtag('config', 'UA-81697994-3');
 }
 </script>
 </head>


### PR DESCRIPTION
API doc was still using the old GA tag. I've switched it to report into the new dashboard. 