### PR TITLE
Prevent GH Pages Jekyll Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
 script:
 - if [[ ! -z "$FEATURE_FLAG" ]]; then bundle exec rake buildAll; fi
 - mkdir -p /tmp/output && bundle exec jekyll build --trace --destination /tmp/output
+- touch /tmp/output/.nojekyll
 deploy:
   provider: pages
   skip_cleanup: true


### PR DESCRIPTION
Due to the filesize of OCCM, GitHub suggested preventing their Jekyll build from running via empty `.nojekyll` file. Instead, just deploy the HTML to the webserver.