### PR TITLE
Update reference_networking_gcp.adoc

### DIFF
--- a/reference_networking_gcp.adoc
+++ b/reference_networking_gcp.adoc
@@ -185,7 +185,9 @@ If you're deploying an HA configuration, these are the firewall rules for Cloud 
 
 === Inbound rules
 
-The source for inbound rules in the predefined security group is 0.0.0.0/0.
+The source for inbound rules in the predefined firewall is 0.0.0.0/0.
+
+To create your own firewall, ensure that you add all networks that need to communicate with the Cloud Volumes ONTAP cluster, but also ensure to add both address ranges to allow the internal Google Load Balancer to function correctly. These addresses are 130.211.0.0/22 and 35.191.0.0/16. For more information, please refer to https://cloud.google.com/load-balancing/docs/tcp#firewall_rules[Google Cloud documentation: Load Balancer Firewall Rules^]
 
 [cols="10,10,80",width=100%,options="header"]
 |===


### PR DESCRIPTION
The address ranges that need to be enabled for the Load Balancer to function are not referenced in the documentation at the moment but are a requirement for customers who build their own firewalls and assign them to CVO on deployment. If these CIDR ranges aren't present in their firewall configs, then CVO deployment will fail or they will lose connectivity to their cluster from any addresses that use the Load Balancer.