### PR TITLE
Clarify the management requirement

### DIFF
--- a/task_tiering_onprem_gcp.adoc
+++ b/task_tiering_onprem_gcp.adoc
@@ -107,7 +107,7 @@ Ensure that the Connector has the required networking connections.
 
 * An outbound internet connection to the Cloud Tiering service over port 443 (HTTPS)
 * An HTTPS connection over port 443 to Google Cloud Storage
-* An HTTPS connection over port 443 to your ONTAP clusters
+* An HTTPS connection over port 443 to your ONTAP clusters management LIF
 
 . Optional: Enable Private Google Access on the subnet where you plan to deploy the Connector.
 +


### PR DESCRIPTION
Connector requires connection over port 443  to the ONTAP clusters management LIF